### PR TITLE
Avatar team

### DIFF
--- a/app/controllers/api/v1/avatar_team_controller.rb
+++ b/app/controllers/api/v1/avatar_team_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class AvatarTeamController < ApplicationController
+      def create
+        user = User.find_by(api_key: params[:api_key])
+
+        if user
+          avatar_team = AvatarTeamFacade.team(params[:count], params[:name])
+          render json: AvatarTeamSerializer.new(avatar_team)
+        else
+          render json: { error: 'Unauthorized' }, status: 401
+        end
+      end
+    end
+  end
+end

--- a/app/facades/avatar_team_facade.rb
+++ b/app/facades/avatar_team_facade.rb
@@ -1,0 +1,14 @@
+class AvatarTeamFacade
+  def self.team(count, name)
+    count = 3 if count.nil?
+    team_service = TeamMateService.my_mates(count)
+    avatar_service = AvatarService.all_avatars.sample(1).first
+
+    avatar = Avatar.new(avatar_service)
+    team = team_service.map do |mate_data|
+      TeamMate.new(mate_data)
+    end
+
+    AvatarTeam.new(name, avatar, team)
+  end
+end

--- a/app/poros/avatar_team.rb
+++ b/app/poros/avatar_team.rb
@@ -1,0 +1,9 @@
+class AvatarTeam
+  attr_reader :team_name, :avatar, :team
+
+  def initialize(name, avatar, team)
+    @team_name = name
+    @avatar = avatar
+    @team = team
+  end
+end

--- a/app/serializers/avatar_team_serializer.rb
+++ b/app/serializers/avatar_team_serializer.rb
@@ -1,0 +1,6 @@
+class AvatarTeamSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_id { nil }
+  attributes :team_name, :avatar, :team
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
       post '/users', to: 'user#create'
 
       post '/sessions', to: 'session#create'
+
+      post '/avatar_team', to: 'avatar_team#create'
     end
   end
 end

--- a/spec/facades/avatar_team_facade_spec.rb
+++ b/spec/facades/avatar_team_facade_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe AvatarTeamFacade do
+  it 'should return a Avatar Team object', :vcr do
+    name = 'Avatar Team'
+    count = 6
+
+    avatar_team = AvatarTeamFacade.team(count, name)
+
+    expect(avatar_team).to be_a AvatarTeam
+    expect(avatar_team.team_name).to be_a String
+    expect(avatar_team.avatar).to be_a Avatar
+    expect(avatar_team.team).to be_a Array
+  end
+end

--- a/spec/fixtures/vcr_cassettes/AvatarTeamFacade/should_return_a_Avatar_Team_object.yml
+++ b/spec/fixtures/vcr_cassettes/AvatarTeamFacade/should_return_a_Avatar_Team_object.yml
@@ -1,0 +1,136 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://last-airbender-api.herokuapp.com/api/v1/characters/random?count=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2338'
+      Etag:
+      - W/"922-I7CHk8fQTMHSi3ctjUPxzuZrBGE"
+      Date:
+      - Mon, 14 Jun 2021 21:55:07 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"_id":"5cf5679a915ecad153ab6a56","allies":["Earth King"],"enemies":["Fire
+        Nation"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/a/ad/Sung.png/revision/latest?cb=20140517113730","name":"Sung","gender":"Male","hair":"Black","weapon":"Earth","profession":"Earth
+        Kingdom general","position":"Defender of the ","affiliation":"Earth Kingdom
+        military","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab6a44","allies":["Freedom
+        Fighters"],"enemies":["Fire Nation"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/6/65/Sneers.png/revision/latest?cb=20181006212849","name":"Sneers","gender":"Male","hair":"Brown","love":"Kori
+        Morishita","weapon":"Axes","profession":"Freedom Fighter ","position":"Scout","affiliation":"
+        Earth Kingdom Freedom Fighters (formerly) Yu Dao Resistance (formerly)","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab6a1e","allies":["Aang"],"enemies":["Koh"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/7/79/Rafa_and_Misu.png/revision/latest?cb=20130811003625","name":"Rafa
+        and Misu","weapon":"Water ","first":"The Search Part Two","__v":0},{"_id":"5cf5679a915ecad153ab69bb","allies":["Toph
+        Beifong"],"enemies":["Terra Triad"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/8/83/Lin_Beifong.png/revision/latest?cb=20120608221629","name":"Lin
+        Beifong","gender":"Female","eye":"Pale green","hair":"Black (gray in middle
+        age)","skin":"Light","love":"Tenzin","weapon":"Metal cables, retractable metal
+        blades, earth, metal","profession":" Police officer Vigilante (formerly)","position":"
+        Chief of Police Earthbending master Metalbending master","affiliation":" Beifong
+        family Republic City Police Department","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab69e1","allies":["The
+        nuns in the "],"enemies":["Fire Nation"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/e/ed/Mother_Superior.png/revision/latest?cb=20130626130958","name":"Mother
+        Superior","gender":"Female","hair":"Gray","profession":"Nun","position":"Head
+        nun","affiliation":"Abbey","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab6a1b","allies":["Iroh"],"enemies":["Pao"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/8/8a/Quon.png/revision/latest?cb=20130701091130","name":"Quon","gender":"Male","hair":"Brown","profession":"Entrepreneur","first":"\"","__v":0}]'
+  recorded_at: Mon, 14 Jun 2021 21:55:07 GMT
+- request:
+    method: get
+    uri: https://last-airbender-api.herokuapp.com/api/v1/characters/avatar
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4990'
+      Etag:
+      - W/"137e-uzlFXcuGrR/5XS2GrLixIaWEbqA"
+      Date:
+      - Mon, 14 Jun 2021 21:55:07 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"allies":["Appa"],"enemies":["Azula"],"_id":"5cf5679a915ecad153ab68c9","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/a/ae/Aang_at_Jasmine_Dragon.png/revision/latest?cb=20130612174003","name":"Aang","gender":"Male","eye":"Gray","hair":"Dark
+        brown ","skin":"Light","love":"Katara ","weapon":"The elements","profession":"
+        Air Nomad culture teacher Airbending instructor Avatar Monk","position":"
+        Co-founder of the United Republic of Nations Fully Realized Avatar","predecessor":"Roku","affiliation":"
+        Air Acolytes Air Nomads Air Scouts (formerly) Team Avatar","first":"\""},{"allies":["Gyatso"],"enemies":["Ozai"],"_id":"5cf5679a915ecad153ab68ca","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/2/21/Into_The_Inferno_Aang.png/revision/latest?cb=20131009060746","name":"Aang
+        (games)","gender":"Male","hair":"Black ","weapon":"The elements, ","profession":"Avatar","position":"Fully
+        Realized Avatar","affiliation":" Air Nomads Team Avatar","first":"Avatar:
+        The Last Airbender video game"},{"allies":["Kya"],"enemies":["Zuko"],"_id":"5cf5679a915ecad153ab68cb","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/7/79/Pilot_-_Aang.png/revision/latest?cb=20120311133235","name":"Aang
+        (pilot)","gender":"Male","hair":"Black (typically shaven)","weapon":"Air,
+        ","profession":" Avatar Monk","position":"Avatar-in-training","affiliation":"
+        Air Nomads Team Avatar","first":"Unaired pilot"},{"allies":["Southern Water
+        Tribe",""],"enemies":["Amon"],"_id":"5cf5679a915ecad153ab69a1","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/c/ca/Korra.png/revision/latest?cb=20150406235047","name":"Korra","gender":"Female","eye":"Cyan","hair":"Dark
+        brown","skin":"Brown","love":" Asami Sato (girlfriend)[6] Mako (boyfriend;
+        formerly)","weapon":"The elements","profession":" Avatar Pro-bender (formerly)","position":"
+        Daughter of the Southern Water Tribe chief Fire Ferrets'' waterbender (formerly)
+        Fully Realized Avatar[7] Member of Tarrlok''s task force (formerly)","predecessor":"
+        Aang (as the Avatar) Hasook (as the waterbending member of the Fire Ferrets)
+        ","affiliation":" Fire Ferrets (formerly) Southern Water Tribe Tarrlok''s
+        task force (formerly) Team Avatar","first":"\""},{"allies":["Northern Water
+        Tribe","Ummi",""],"enemies":["Koh"],"_id":"5cf5679a915ecad153ab69a5","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/d1/Kuruk.png/revision/latest?cb=20081225191014","name":"Kuruk","gender":"Male","hair":"Black","love":"Ummi","weapon":"The
+        ","profession":"Avatar","position":"Fully Realized Avatar","predecessor":"Yangchen","first":"
+        \"The Avatar State\"  (actual) Escape from the Spirit World  (named)"},{"allies":["Koko","Yun",""],"enemies":["Tagaka"],"_id":"5cf5679a915ecad153ab69ac","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/0/07/Avatar_Kyoshi.png/revision/latest?cb=20140215111846","name":"Kyoshi","gender":"Female","hair":"Brown","love":"Koko''s
+        father ","weapon":"The elements","profession":" Avatar Earthbending instructor","position":"
+        Founder of the Kyoshi Warriors and Dai Li Fully Realized Avatar Governor of
+        Kyoshi Island (formerly)[3]","predecessor":"Kuruk","affiliation":"Kyoshi Island
+        inhabitants","first":" \"The Southern Air Temple\"(statue and painting) \"The
+        Avatar State\"(vision)"},{"allies":["Fang"],"enemies":["Sozin"],"_id":"5cf5679a915ecad153ab6a25","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/f/f6/Roku.png/revision/latest?cb=20120601014953","name":"Roku","gender":"Male","eye":"Amber
+        brown","hair":"White ","skin":"Light","love":"Ta Min","weapon":"The elements","profession":"Avatar","position":"
+        Fully Realized Avatar Upper-class Fire Nation citizen","predecessor":"Kyoshi","first":"
+        \"The Southern Air Temple\" (as a statue) \"Winter Solstice, Part 2: Avatar
+        Roku\" (actual)"},{"allies":["Mula"],"enemies":["Chou family"],"_id":"5cf5679a915ecad153ab6a89","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/5/51/Wan.png/revision/latest?cb=20130720233908","name":"Wan","gender":"Male","eye":"Deep
+        copper","hair":"Black","skin":"Pale","weapon":"The elements","profession":"Avatar","position":"First
+        Avatar","affiliation":"Raava","first":"\""},{"allies":["Air Nomads","all Avatars",""],"enemies":["Old
+        Iron"],"_id":"5cf5679a915ecad153ab6a9e","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/db/Yangchen.png/revision/latest?cb=20131023040543","name":"Yangchen","gender":"Female","hair":"Brown","skin":"Light","weapon":"The
+        elements","profession":" Avatar Nun","position":"Fully Realized Avatar","predecessor":"Yangchen''s
+        predecessor","first":"\""},{"allies":["All Avatars"],"enemies":[],"_id":"5cf5679a915ecad153ab6a9f","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/b/b3/Unnamed_fire_Avatar_close-up.png/revision/latest?cb=20131022002330","name":"Yangchen''s
+        predecessor","gender":"Male","hair":"Brown","weapon":"The elements","profession":"Avatar","position":"Fully
+        Realized Avatar","predecessor":"Unnamed male earth ","first":"\""}]'
+  recorded_at: Mon, 14 Jun 2021 21:55:07 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Avatar_Team_API/can_create_a_Avatar_Team.yml
+++ b/spec/fixtures/vcr_cassettes/Avatar_Team_API/can_create_a_Avatar_Team.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://last-airbender-api.herokuapp.com/api/v1/characters/random?count=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1113'
+      Etag:
+      - W/"459-11lu4l3XxwLxAnZCqPfCXXNnZFM"
+      Date:
+      - Mon, 14 Jun 2021 20:35:42 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"_id":"5cf5679a915ecad153ab692d","allies":["His wife"],"enemies":["Fire
+        Nation"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/f/f0/Fisherman.png/revision/latest?cb=20130714140302","name":"Fisherman","gender":"Male","hair":"White","love":"His
+        wife","profession":"Fisherman","affiliation":"Earth Kingdom","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab69a2","allies":["Earth
+        Kingdom",""],"enemies":["Fire Nation"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/5/5e/Kuei.png/revision/latest?cb=20130627084042","name":"Kuei","gender":"Male","eye":"Light
+        green","hair":"Black","position":"Earth King","predecessor":"The 51st Earth
+        King","affiliation":" Earth Kingdom government Earth Kingdom Royal Family","first":"
+        \"City of Walls and Secrets\" (actual) \"The Earth King\" (speaking role)","__v":0},{"_id":"5cf5679a915ecad153ab6a88","allies":[],"enemies":[],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/c/c3/Wacky_Wushu.png/revision/latest?cb=20130914205154","name":"Wacky
+        Wushu","gender":"Male","weapon":"Water","profession":"Entertainer","first":"\"","__v":0}]'
+  recorded_at: Mon, 14 Jun 2021 20:35:42 GMT
+- request:
+    method: get
+    uri: https://last-airbender-api.herokuapp.com/api/v1/characters/avatar
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4990'
+      Etag:
+      - W/"137e-uzlFXcuGrR/5XS2GrLixIaWEbqA"
+      Date:
+      - Mon, 14 Jun 2021 20:35:43 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"allies":["Appa"],"enemies":["Azula"],"_id":"5cf5679a915ecad153ab68c9","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/a/ae/Aang_at_Jasmine_Dragon.png/revision/latest?cb=20130612174003","name":"Aang","gender":"Male","eye":"Gray","hair":"Dark
+        brown ","skin":"Light","love":"Katara ","weapon":"The elements","profession":"
+        Air Nomad culture teacher Airbending instructor Avatar Monk","position":"
+        Co-founder of the United Republic of Nations Fully Realized Avatar","predecessor":"Roku","affiliation":"
+        Air Acolytes Air Nomads Air Scouts (formerly) Team Avatar","first":"\""},{"allies":["Gyatso"],"enemies":["Ozai"],"_id":"5cf5679a915ecad153ab68ca","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/2/21/Into_The_Inferno_Aang.png/revision/latest?cb=20131009060746","name":"Aang
+        (games)","gender":"Male","hair":"Black ","weapon":"The elements, ","profession":"Avatar","position":"Fully
+        Realized Avatar","affiliation":" Air Nomads Team Avatar","first":"Avatar:
+        The Last Airbender video game"},{"allies":["Kya"],"enemies":["Zuko"],"_id":"5cf5679a915ecad153ab68cb","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/7/79/Pilot_-_Aang.png/revision/latest?cb=20120311133235","name":"Aang
+        (pilot)","gender":"Male","hair":"Black (typically shaven)","weapon":"Air,
+        ","profession":" Avatar Monk","position":"Avatar-in-training","affiliation":"
+        Air Nomads Team Avatar","first":"Unaired pilot"},{"allies":["Southern Water
+        Tribe",""],"enemies":["Amon"],"_id":"5cf5679a915ecad153ab69a1","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/c/ca/Korra.png/revision/latest?cb=20150406235047","name":"Korra","gender":"Female","eye":"Cyan","hair":"Dark
+        brown","skin":"Brown","love":" Asami Sato (girlfriend)[6] Mako (boyfriend;
+        formerly)","weapon":"The elements","profession":" Avatar Pro-bender (formerly)","position":"
+        Daughter of the Southern Water Tribe chief Fire Ferrets'' waterbender (formerly)
+        Fully Realized Avatar[7] Member of Tarrlok''s task force (formerly)","predecessor":"
+        Aang (as the Avatar) Hasook (as the waterbending member of the Fire Ferrets)
+        ","affiliation":" Fire Ferrets (formerly) Southern Water Tribe Tarrlok''s
+        task force (formerly) Team Avatar","first":"\""},{"allies":["Northern Water
+        Tribe","Ummi",""],"enemies":["Koh"],"_id":"5cf5679a915ecad153ab69a5","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/d1/Kuruk.png/revision/latest?cb=20081225191014","name":"Kuruk","gender":"Male","hair":"Black","love":"Ummi","weapon":"The
+        ","profession":"Avatar","position":"Fully Realized Avatar","predecessor":"Yangchen","first":"
+        \"The Avatar State\"  (actual) Escape from the Spirit World  (named)"},{"allies":["Koko","Yun",""],"enemies":["Tagaka"],"_id":"5cf5679a915ecad153ab69ac","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/0/07/Avatar_Kyoshi.png/revision/latest?cb=20140215111846","name":"Kyoshi","gender":"Female","hair":"Brown","love":"Koko''s
+        father ","weapon":"The elements","profession":" Avatar Earthbending instructor","position":"
+        Founder of the Kyoshi Warriors and Dai Li Fully Realized Avatar Governor of
+        Kyoshi Island (formerly)[3]","predecessor":"Kuruk","affiliation":"Kyoshi Island
+        inhabitants","first":" \"The Southern Air Temple\"(statue and painting) \"The
+        Avatar State\"(vision)"},{"allies":["Fang"],"enemies":["Sozin"],"_id":"5cf5679a915ecad153ab6a25","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/f/f6/Roku.png/revision/latest?cb=20120601014953","name":"Roku","gender":"Male","eye":"Amber
+        brown","hair":"White ","skin":"Light","love":"Ta Min","weapon":"The elements","profession":"Avatar","position":"
+        Fully Realized Avatar Upper-class Fire Nation citizen","predecessor":"Kyoshi","first":"
+        \"The Southern Air Temple\" (as a statue) \"Winter Solstice, Part 2: Avatar
+        Roku\" (actual)"},{"allies":["Mula"],"enemies":["Chou family"],"_id":"5cf5679a915ecad153ab6a89","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/5/51/Wan.png/revision/latest?cb=20130720233908","name":"Wan","gender":"Male","eye":"Deep
+        copper","hair":"Black","skin":"Pale","weapon":"The elements","profession":"Avatar","position":"First
+        Avatar","affiliation":"Raava","first":"\""},{"allies":["Air Nomads","all Avatars",""],"enemies":["Old
+        Iron"],"_id":"5cf5679a915ecad153ab6a9e","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/db/Yangchen.png/revision/latest?cb=20131023040543","name":"Yangchen","gender":"Female","hair":"Brown","skin":"Light","weapon":"The
+        elements","profession":" Avatar Nun","position":"Fully Realized Avatar","predecessor":"Yangchen''s
+        predecessor","first":"\""},{"allies":["All Avatars"],"enemies":[],"_id":"5cf5679a915ecad153ab6a9f","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/b/b3/Unnamed_fire_Avatar_close-up.png/revision/latest?cb=20131022002330","name":"Yangchen''s
+        predecessor","gender":"Male","hair":"Brown","weapon":"The elements","profession":"Avatar","position":"Fully
+        Realized Avatar","predecessor":"Unnamed male earth ","first":"\""}]'
+  recorded_at: Mon, 14 Jun 2021 20:35:43 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Avatar_Team_API/can_not_work_without_count.yml
+++ b/spec/fixtures/vcr_cassettes/Avatar_Team_API/can_not_work_without_count.yml
@@ -1,0 +1,129 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://last-airbender-api.herokuapp.com/api/v1/characters/random?count=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1255'
+      Etag:
+      - W/"4e7-4LciWIsVhTmav2oLxZuy6d/ECkA"
+      Date:
+      - Mon, 14 Jun 2021 21:08:05 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"_id":"5cf5679a915ecad153ab6977","allies":["Fire Nation",""],"enemies":["Amon"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/3/34/Iroh_%28United_Forces_general%29.png/revision/latest?cb=20140421100233","name":"Iroh
+        (United Forces general)","gender":"Male","hair":"Black","weapon":"Fire, lightning","profession":"Military
+        official","position":" Firebending master General of the United Forces Prince
+        of the Fire Nation United Forces general","affiliation":" Fire Nation Royal
+        Family United Forces","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab690e","allies":[],"enemies":["Tenzin"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/9/9a/Dark_spider_spirit.png/revision/latest?cb=20141109112441","name":"Dark
+        spider spirit","weapon":"Webbing","position":"Spirit","affiliation":"Spirit
+        World","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab6936","allies":["Team
+        Avatar"],"enemies":["Fire Nation"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/3/33/Forest_spirit.png/revision/latest?cb=20140529055837","name":"Forest
+        spirit","gender":"Male","hair":" Brown (beast form) White (human form)","profession":"Spirit","position":"Forest
+        spirit","affiliation":" Earth Kingdom Spirit World","first":"\"","__v":0}]'
+  recorded_at: Mon, 14 Jun 2021 21:08:05 GMT
+- request:
+    method: get
+    uri: https://last-airbender-api.herokuapp.com/api/v1/characters/avatar
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4990'
+      Etag:
+      - W/"137e-uzlFXcuGrR/5XS2GrLixIaWEbqA"
+      Date:
+      - Mon, 14 Jun 2021 21:08:05 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"allies":["Appa"],"enemies":["Azula"],"_id":"5cf5679a915ecad153ab68c9","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/a/ae/Aang_at_Jasmine_Dragon.png/revision/latest?cb=20130612174003","name":"Aang","gender":"Male","eye":"Gray","hair":"Dark
+        brown ","skin":"Light","love":"Katara ","weapon":"The elements","profession":"
+        Air Nomad culture teacher Airbending instructor Avatar Monk","position":"
+        Co-founder of the United Republic of Nations Fully Realized Avatar","predecessor":"Roku","affiliation":"
+        Air Acolytes Air Nomads Air Scouts (formerly) Team Avatar","first":"\""},{"allies":["Gyatso"],"enemies":["Ozai"],"_id":"5cf5679a915ecad153ab68ca","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/2/21/Into_The_Inferno_Aang.png/revision/latest?cb=20131009060746","name":"Aang
+        (games)","gender":"Male","hair":"Black ","weapon":"The elements, ","profession":"Avatar","position":"Fully
+        Realized Avatar","affiliation":" Air Nomads Team Avatar","first":"Avatar:
+        The Last Airbender video game"},{"allies":["Kya"],"enemies":["Zuko"],"_id":"5cf5679a915ecad153ab68cb","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/7/79/Pilot_-_Aang.png/revision/latest?cb=20120311133235","name":"Aang
+        (pilot)","gender":"Male","hair":"Black (typically shaven)","weapon":"Air,
+        ","profession":" Avatar Monk","position":"Avatar-in-training","affiliation":"
+        Air Nomads Team Avatar","first":"Unaired pilot"},{"allies":["Southern Water
+        Tribe",""],"enemies":["Amon"],"_id":"5cf5679a915ecad153ab69a1","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/c/ca/Korra.png/revision/latest?cb=20150406235047","name":"Korra","gender":"Female","eye":"Cyan","hair":"Dark
+        brown","skin":"Brown","love":" Asami Sato (girlfriend)[6] Mako (boyfriend;
+        formerly)","weapon":"The elements","profession":" Avatar Pro-bender (formerly)","position":"
+        Daughter of the Southern Water Tribe chief Fire Ferrets'' waterbender (formerly)
+        Fully Realized Avatar[7] Member of Tarrlok''s task force (formerly)","predecessor":"
+        Aang (as the Avatar) Hasook (as the waterbending member of the Fire Ferrets)
+        ","affiliation":" Fire Ferrets (formerly) Southern Water Tribe Tarrlok''s
+        task force (formerly) Team Avatar","first":"\""},{"allies":["Northern Water
+        Tribe","Ummi",""],"enemies":["Koh"],"_id":"5cf5679a915ecad153ab69a5","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/d1/Kuruk.png/revision/latest?cb=20081225191014","name":"Kuruk","gender":"Male","hair":"Black","love":"Ummi","weapon":"The
+        ","profession":"Avatar","position":"Fully Realized Avatar","predecessor":"Yangchen","first":"
+        \"The Avatar State\"  (actual) Escape from the Spirit World  (named)"},{"allies":["Koko","Yun",""],"enemies":["Tagaka"],"_id":"5cf5679a915ecad153ab69ac","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/0/07/Avatar_Kyoshi.png/revision/latest?cb=20140215111846","name":"Kyoshi","gender":"Female","hair":"Brown","love":"Koko''s
+        father ","weapon":"The elements","profession":" Avatar Earthbending instructor","position":"
+        Founder of the Kyoshi Warriors and Dai Li Fully Realized Avatar Governor of
+        Kyoshi Island (formerly)[3]","predecessor":"Kuruk","affiliation":"Kyoshi Island
+        inhabitants","first":" \"The Southern Air Temple\"(statue and painting) \"The
+        Avatar State\"(vision)"},{"allies":["Fang"],"enemies":["Sozin"],"_id":"5cf5679a915ecad153ab6a25","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/f/f6/Roku.png/revision/latest?cb=20120601014953","name":"Roku","gender":"Male","eye":"Amber
+        brown","hair":"White ","skin":"Light","love":"Ta Min","weapon":"The elements","profession":"Avatar","position":"
+        Fully Realized Avatar Upper-class Fire Nation citizen","predecessor":"Kyoshi","first":"
+        \"The Southern Air Temple\" (as a statue) \"Winter Solstice, Part 2: Avatar
+        Roku\" (actual)"},{"allies":["Mula"],"enemies":["Chou family"],"_id":"5cf5679a915ecad153ab6a89","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/5/51/Wan.png/revision/latest?cb=20130720233908","name":"Wan","gender":"Male","eye":"Deep
+        copper","hair":"Black","skin":"Pale","weapon":"The elements","profession":"Avatar","position":"First
+        Avatar","affiliation":"Raava","first":"\""},{"allies":["Air Nomads","all Avatars",""],"enemies":["Old
+        Iron"],"_id":"5cf5679a915ecad153ab6a9e","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/db/Yangchen.png/revision/latest?cb=20131023040543","name":"Yangchen","gender":"Female","hair":"Brown","skin":"Light","weapon":"The
+        elements","profession":" Avatar Nun","position":"Fully Realized Avatar","predecessor":"Yangchen''s
+        predecessor","first":"\""},{"allies":["All Avatars"],"enemies":[],"_id":"5cf5679a915ecad153ab6a9f","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/b/b3/Unnamed_fire_Avatar_close-up.png/revision/latest?cb=20131022002330","name":"Yangchen''s
+        predecessor","gender":"Male","hair":"Brown","weapon":"The elements","profession":"Avatar","position":"Fully
+        Realized Avatar","predecessor":"Unnamed male earth ","first":"\""}]'
+  recorded_at: Mon, 14 Jun 2021 21:08:05 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Avatar_Team_API/can_work_without_giving_a_count.yml
+++ b/spec/fixtures/vcr_cassettes/Avatar_Team_API/can_work_without_giving_a_count.yml
@@ -1,0 +1,129 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://last-airbender-api.herokuapp.com/api/v1/characters/random?count=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1175'
+      Etag:
+      - W/"497-9NeXzn73iUUl9WR3VeZdQUl5Owg"
+      Date:
+      - Mon, 14 Jun 2021 21:10:47 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"_id":"5cf5679a915ecad153ab6946","allies":["The Boulder"],"enemies":["Toph
+        Beifong"],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/dd/Gopher.png/revision/latest?cb=20140317211135","name":"The
+        Gopher","gender":"Male","hair":"Brown ","weapon":"Earth","profession":"Professional
+        earthbending fighter","affiliation":"Earth Rumble VI","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab6991","allies":["Bhanti
+        Tribe",""],"enemies":[],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/b/b7/Karu.png/revision/latest?cb=20131020004017","name":"Karu","gender":"Male","hair":"Gray","profession":"Sage","affiliation":"Bhanti
+        Tribe","first":"\"","__v":0},{"_id":"5cf5679a915ecad153ab6a4f","allies":["Fire
+        Nation",""],"enemies":["Roku",""],"photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/a/aa/Old_Sozin.png/revision/latest?cb=20110112175420","name":"Sozin","gender":"Male","eye":"Gold","hair":"White
+        ","weapon":"Fire","position":" Crown Prince of the Fire Nation (formerly)
+        Fire Lord Firebending master Instigator of the Hundred Year War","predecessor":"His
+        father ","affiliation":" Fire Nation Fire Nation Royal Family","first":"\"","__v":0}]'
+  recorded_at: Mon, 14 Jun 2021 21:10:48 GMT
+- request:
+    method: get
+    uri: https://last-airbender-api.herokuapp.com/api/v1/characters/avatar
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4990'
+      Etag:
+      - W/"137e-uzlFXcuGrR/5XS2GrLixIaWEbqA"
+      Date:
+      - Mon, 14 Jun 2021 21:10:48 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"allies":["Appa"],"enemies":["Azula"],"_id":"5cf5679a915ecad153ab68c9","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/a/ae/Aang_at_Jasmine_Dragon.png/revision/latest?cb=20130612174003","name":"Aang","gender":"Male","eye":"Gray","hair":"Dark
+        brown ","skin":"Light","love":"Katara ","weapon":"The elements","profession":"
+        Air Nomad culture teacher Airbending instructor Avatar Monk","position":"
+        Co-founder of the United Republic of Nations Fully Realized Avatar","predecessor":"Roku","affiliation":"
+        Air Acolytes Air Nomads Air Scouts (formerly) Team Avatar","first":"\""},{"allies":["Gyatso"],"enemies":["Ozai"],"_id":"5cf5679a915ecad153ab68ca","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/2/21/Into_The_Inferno_Aang.png/revision/latest?cb=20131009060746","name":"Aang
+        (games)","gender":"Male","hair":"Black ","weapon":"The elements, ","profession":"Avatar","position":"Fully
+        Realized Avatar","affiliation":" Air Nomads Team Avatar","first":"Avatar:
+        The Last Airbender video game"},{"allies":["Kya"],"enemies":["Zuko"],"_id":"5cf5679a915ecad153ab68cb","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/7/79/Pilot_-_Aang.png/revision/latest?cb=20120311133235","name":"Aang
+        (pilot)","gender":"Male","hair":"Black (typically shaven)","weapon":"Air,
+        ","profession":" Avatar Monk","position":"Avatar-in-training","affiliation":"
+        Air Nomads Team Avatar","first":"Unaired pilot"},{"allies":["Southern Water
+        Tribe",""],"enemies":["Amon"],"_id":"5cf5679a915ecad153ab69a1","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/c/ca/Korra.png/revision/latest?cb=20150406235047","name":"Korra","gender":"Female","eye":"Cyan","hair":"Dark
+        brown","skin":"Brown","love":" Asami Sato (girlfriend)[6] Mako (boyfriend;
+        formerly)","weapon":"The elements","profession":" Avatar Pro-bender (formerly)","position":"
+        Daughter of the Southern Water Tribe chief Fire Ferrets'' waterbender (formerly)
+        Fully Realized Avatar[7] Member of Tarrlok''s task force (formerly)","predecessor":"
+        Aang (as the Avatar) Hasook (as the waterbending member of the Fire Ferrets)
+        ","affiliation":" Fire Ferrets (formerly) Southern Water Tribe Tarrlok''s
+        task force (formerly) Team Avatar","first":"\""},{"allies":["Northern Water
+        Tribe","Ummi",""],"enemies":["Koh"],"_id":"5cf5679a915ecad153ab69a5","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/d1/Kuruk.png/revision/latest?cb=20081225191014","name":"Kuruk","gender":"Male","hair":"Black","love":"Ummi","weapon":"The
+        ","profession":"Avatar","position":"Fully Realized Avatar","predecessor":"Yangchen","first":"
+        \"The Avatar State\"  (actual) Escape from the Spirit World  (named)"},{"allies":["Koko","Yun",""],"enemies":["Tagaka"],"_id":"5cf5679a915ecad153ab69ac","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/0/07/Avatar_Kyoshi.png/revision/latest?cb=20140215111846","name":"Kyoshi","gender":"Female","hair":"Brown","love":"Koko''s
+        father ","weapon":"The elements","profession":" Avatar Earthbending instructor","position":"
+        Founder of the Kyoshi Warriors and Dai Li Fully Realized Avatar Governor of
+        Kyoshi Island (formerly)[3]","predecessor":"Kuruk","affiliation":"Kyoshi Island
+        inhabitants","first":" \"The Southern Air Temple\"(statue and painting) \"The
+        Avatar State\"(vision)"},{"allies":["Fang"],"enemies":["Sozin"],"_id":"5cf5679a915ecad153ab6a25","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/f/f6/Roku.png/revision/latest?cb=20120601014953","name":"Roku","gender":"Male","eye":"Amber
+        brown","hair":"White ","skin":"Light","love":"Ta Min","weapon":"The elements","profession":"Avatar","position":"
+        Fully Realized Avatar Upper-class Fire Nation citizen","predecessor":"Kyoshi","first":"
+        \"The Southern Air Temple\" (as a statue) \"Winter Solstice, Part 2: Avatar
+        Roku\" (actual)"},{"allies":["Mula"],"enemies":["Chou family"],"_id":"5cf5679a915ecad153ab6a89","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/5/51/Wan.png/revision/latest?cb=20130720233908","name":"Wan","gender":"Male","eye":"Deep
+        copper","hair":"Black","skin":"Pale","weapon":"The elements","profession":"Avatar","position":"First
+        Avatar","affiliation":"Raava","first":"\""},{"allies":["Air Nomads","all Avatars",""],"enemies":["Old
+        Iron"],"_id":"5cf5679a915ecad153ab6a9e","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/d/db/Yangchen.png/revision/latest?cb=20131023040543","name":"Yangchen","gender":"Female","hair":"Brown","skin":"Light","weapon":"The
+        elements","profession":" Avatar Nun","position":"Fully Realized Avatar","predecessor":"Yangchen''s
+        predecessor","first":"\""},{"allies":["All Avatars"],"enemies":[],"_id":"5cf5679a915ecad153ab6a9f","photoUrl":"https://vignette.wikia.nocookie.net/avatar/images/b/b3/Unnamed_fire_Avatar_close-up.png/revision/latest?cb=20131022002330","name":"Yangchen''s
+        predecessor","gender":"Male","hair":"Brown","weapon":"The elements","profession":"Avatar","position":"Fully
+        Realized Avatar","predecessor":"Unnamed male earth ","first":"\""}]'
+  recorded_at: Mon, 14 Jun 2021 21:10:48 GMT
+recorded_with: VCR 6.0.0

--- a/spec/poros/avatar_team_spec.rb
+++ b/spec/poros/avatar_team_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe AvatarTeam do
+  it 'exists' do
+    name = 'Team Goat'
+    avatar_data = {
+      _id: '1',
+      name: 'Roku',
+      weapon: 'The elements',
+      profession: 'Protector of all nations'
+    }
+
+    avatar = Avatar.new(avatar_data)
+
+    team_data1 = {
+      _id: '1',
+      name: 'Kevin Cuadros',
+      position: 'Leader',
+      weapon: 'Fire',
+      profession: 'Security Guard'
+    }
+
+    team_data2 = {
+      _id: '2',
+      name: 'Kevin Cuadros',
+      position: 'Leader',
+      weapon: 'Water',
+      profession: 'Security Guard'
+    }
+
+    team_data3 = {
+      _id: '3',
+      name: 'Kevin Cuadros',
+      position: 'Leader',
+      weapon: 'Earth',
+      profession: 'Security Guard'
+    }
+
+    mates = [team_data1, team_data2, team_data3]
+
+    team = mates.map do |mate_data|
+      TeamMate.new(mate_data)
+    end
+
+    avatar_team = AvatarTeam.new(name, avatar, team)
+
+    expect(avatar_team).to be_a AvatarTeam
+    expect(avatar_team.team_name).to eq('Team Goat')
+    expect(avatar_team.avatar).to be_a Avatar
+    expect(avatar_team.team).to be_a Array
+    expect(avatar_team.team.first).to be_a TeamMate
+  end
+end

--- a/spec/requests/api/v1/avatar_team_request_spec.rb
+++ b/spec/requests/api/v1/avatar_team_request_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe 'Avatar Team API' do
+  it 'can create a Avatar Team', :vcr do
+    user = create(:user)
+
+    team = {
+      'name': 'Team Hero',
+      'count': 3,
+      'api_key': user.api_key
+    }
+
+    post '/api/v1/avatar_team', params: team.to_json,
+                                headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+
+    expect(response).to be_successful
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    avatar_team = json[:data]
+
+    expect(avatar_team).to be_a Hash
+    expect(avatar_team).to have_key :type
+    expect(avatar_team[:type]).to eq('avatar_team')
+    expect(avatar_team).to have_key :attributes
+    expect(avatar_team[:attributes].keys).to eq(%i[team_name avatar team])
+    expect(avatar_team[:attributes][:team_name]).to be_a String
+    expect(avatar_team[:attributes][:avatar]).to be_a Hash
+    expect(avatar_team[:attributes][:team]).to be_a Array
+  end
+
+  it 'fails with incorrect api_key' do
+    team = {
+      'name': 'Team Hero',
+      'count': 3,
+      'api_key': 'bfhiwebfiuwbiukcnjdqnj'
+    }
+
+    post '/api/v1/avatar_team', params: team.to_json,
+                                headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+
+    expect(response).to_not be_successful
+    expect(response.status).to eq(401)
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(json).to have_key :error
+    expect(json[:error]).to eq('Unauthorized')
+  end
+
+  it 'can work without giving a count', :vcr do
+    user = create(:user)
+
+    team = {
+      'name': 'Team Hero',
+      'api_key': user.api_key
+    }
+
+    post '/api/v1/avatar_team', params: team.to_json,
+                                headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+
+    expect(response).to be_successful
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    avatar_team = json[:data]
+
+    expect(avatar_team[:attributes][:team]).to be_a Array
+    expect(avatar_team[:attributes][:team].length).to eq(3)
+  end
+end


### PR DESCRIPTION
This branch we add the ability for a authorized user to have the possibility of creating their own Team Avatar.

All tests pass

user = create(:user)

    team = {
      'name': 'Team Hero',
      'count': 3,
      'api_key': user.api_key
    }

    post '/api/v1/avatar_team', params: team.to_json,
                                headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
